### PR TITLE
Replace Tuple with Sequence for the _Options type

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -12,7 +12,7 @@ __version__: str
 # a bit segfaulty and doesn't adequately validate the option keys), but that
 # didn't quite work out. Maybe it's something we can come back to?
 _OptionKeyValue = typing.Tuple[str, typing.Any]
-_Options = typing.Tuple[_OptionKeyValue, ...]
+_Options = typing.Sequence[_OptionKeyValue]
 
 
 class Compression(enum.IntEnum):


### PR DESCRIPTION
The current implementation of `_Options` requires a variable length `Tuple`. A `Sequence` is more general and covers `List` as a common alternative.