### PR TITLE
Update CallIterator.__iter__() return type

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -483,7 +483,7 @@ class UnaryUnaryClientInterceptor(typing.Generic[TRequest, TResponse]):
 
 
 class CallIterator(typing.Generic[TResponse], Call):
-    def __iter__(self) -> typing.Iterable[TResponse]: ...
+    def __iter__(self) -> typing.Iterator[TResponse]: ...
 
 
 class UnaryStreamClientInterceptor(typing.Generic[TRequest, TResponse]):


### PR DESCRIPTION
`__iter__` should return an iterator, and not an iterable. Seems like a small oversight.