### PR TITLE
Fix the return type of composite_channel_credentials

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -110,7 +110,7 @@ def composite_channel_credentials(
     channel_credentials: ChannelCredentials,
     call_credentials: CallCredentials,
     *rest: CallCredentials,
-) -> CallCredentials:
+) -> ChannelCredentials:
     ...
 
 


### PR DESCRIPTION
Likely a copy-paste artifact.
The implementation does return `ChannelCredentials`:
https://github.com/grpc/grpc/blob/a72c72f6e353ffeba7d3a268e7daa8916d48dac0/src/python/grpcio/grpc/__init__.py#L1672-L1687