### PR TITLE
Only require typing_extensions on Python 3.7 and older

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Install using pip::
 
 Tests (courtesy of `pytest-mypy-plugins <https://github.com/typeddjango/pytest-mypy-plugins>`_)::
 
-    pip install -r dev-requirements.txt
+    pip install -r requirements-dev.txt
     ./tools.sh test
 
 

--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -1,9 +1,14 @@
 import enum
 import threading
 import typing
+import sys
 from concurrent import futures
 from types import TracebackType
-from typing_extensions import Literal
+if sys.version_info[:2] >= (3, 8):
+    from typing import Literal
+else:
+    # Python 3.7 and earlier
+    from typing_extensions import Literal
 
 __version__: str
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 __version__ = "1.24.6"
 
 dependencies = [
-    'mypy>=0.730',
+    'mypy>=0.902',
     "typing-extensions; python_version<'3.8'",
     'grpcio',
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ __version__ = "1.24.6"
 
 dependencies = [
     'mypy>=0.730',
-    'typing-extensions',
+    "typing-extensions; python_version<'3.8'",
     'grpcio',
 ]
 

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -2,15 +2,15 @@
   main: |
     from grpc import Channel, Server
     
-    reveal_type(Channel())  # N: Revealed type is 'grpc.Channel'
-    reveal_type(Server())   # N: Revealed type is 'grpc.Server'
+    reveal_type(Channel())  # N: Revealed type is "grpc.Channel"
+    reveal_type(Server())   # N: Revealed type is "grpc.Server"
 
 - case: grpc_status
   main: |
     from grpc import Status
     from grpc_status import to_status
     
-    # XXX: to_status actually expects a 'google.rpc.status.Status',
+    # XXX: to_status actually expects a "google.rpc.status.Status",
     # but I haven't set up the stubs properly for that yet.
     status: Status = to_status(None)
     
@@ -18,9 +18,9 @@
   main: |
     import grpc
 
-    reveal_type(grpc.insecure_channel("target", ()))  # N: Revealed type is 'grpc.Channel'
-    reveal_type(grpc.insecure_channel("target", (("a", "b"),)))  # N: Revealed type is 'grpc.Channel'
-    reveal_type(grpc.insecure_channel("target", (("a", "b"), ("c", "d"))))  # N: Revealed type is 'grpc.Channel'
+    reveal_type(grpc.insecure_channel("target", ()))  # N: Revealed type is "grpc.Channel"
+    reveal_type(grpc.insecure_channel("target", (("a", "b"),)))  # N: Revealed type is "grpc.Channel"
+    reveal_type(grpc.insecure_channel("target", (("a", "b"), ("c", "d"))))  # N: Revealed type is "grpc.Channel"
 
 - case: grpc_channel_options_supports_list
   main: |
@@ -35,23 +35,23 @@
     import grpc
 
     creds = grpc.local_channel_credentials(grpc.LocalConnectionType.LOCAL_TCP)
-    reveal_type(creds)  # N: Revealed type is 'grpc.ChannelCredentials'
+    reveal_type(creds)  # N: Revealed type is "grpc.ChannelCredentials"
 
 - case: client_call_details_optionals
   main: |
     import grpc
 
     creds = grpc.ClientCallDetails()
-    reveal_type(creds.method)  # N: Revealed type is 'builtins.str'
-    reveal_type(creds.timeout)  # N: Revealed type is 'Union[builtins.float, None]'
+    reveal_type(creds.method)  # N: Revealed type is "builtins.str"
+    reveal_type(creds.timeout)  # N: Revealed type is "Union[builtins.float, None]"
 
 - case: service_context_abort
   main: |
     import grpc
 
     ctx = grpc.ServicerContext()
-    reveal_type(ctx.abort(grpc.StatusCode.OK, "msg"))  # N: Revealed type is '<nothing>'
-    reveal_type(ctx.abort_with_status(grpc.Status()))  # N: Revealed type is '<nothing>'
+    reveal_type(ctx.abort(grpc.StatusCode.OK, "msg"))  # N: Revealed type is "<nothing>"
+    reveal_type(ctx.abort_with_status(grpc.Status()))  # N: Revealed type is "<nothing>"
 
 - case: call_iterator_pr10
   main: |
@@ -61,5 +61,5 @@
     call_iter: grpc.CallIterator[str] = t.cast(t.Any, None)
     for call in call_iter:
       pass
-    reveal_type(call)  # N: Revealed type is 'builtins.str*'
+    reveal_type(call)  # N: Revealed type is "builtins.str*"
   


### PR DESCRIPTION
Corrects a typo in README.rst.

Newer mypy versions output double quotes instead of single quotes.