### PR TITLE
server() expects list of ServerInterceptor

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -30,7 +30,7 @@ class Compression(enum.IntEnum):
 class LocalConnectionType(enum.Enum):
     UDS = ...
     LOCAL_TCP = ...
- 
+
 
 # XXX: not documented, needs more investigation.
 # Some evidence:
@@ -131,7 +131,7 @@ def composite_channel_credentials(
 def server(
     thread_pool: futures.ThreadPoolExecutor,
     handlers: typing.Optional[typing.List[GenericRpcHandler]] = None,
-    interceptors: typing.Optional[typing.List[Interceptor]] = None,
+    interceptors: typing.Optional[typing.List[ServerInterceptor]] = None,
     options: typing.Optional[_Options] = None,
     maximum_concurrent_rpcs: typing.Optional[int] = None,
     compression: typing.Optional[Compression] = None,
@@ -602,7 +602,7 @@ class ServerInterceptor(typing.Generic[TRequest, TResponse]):
     def intercept_service(
         self,
         continuation: typing.Callable[
-            [HandlerCallDetails], 
+            [HandlerCallDetails],
             typing.Optional[RpcMethodHandler[TRequest, TResponse]]
         ],
         handler_call_details: HandlerCallDetails,


### PR DESCRIPTION
The current typehint wants a list of various client interceptors, when in reality it should be a list of `ServerInterceptor` as per the docs:
> interceptors: An optional list of ServerInterceptor objects that observe
        and optionally manipulate the incoming RPCs before handing them over to
        handlers. The interceptors are given control in the order they are
        specified. This is an EXPERIMENTAL API.