### PR TITLE
Fix the `method` property on the HandlerCallDetails

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -584,7 +584,7 @@ class RpcMethodHandler(typing.Generic[TRequest, TResponse]):
 
 
 class HandlerCallDetails:
-    method_name: str
+    method: str
     invocation_metadata: Metadata
 
 


### PR DESCRIPTION
According to [official docs](https://grpc.github.io/grpc/python/grpc.html#grpc.HandlerCallDetails) (as well as what I see happening in code), `HandlerCallDetails` has a `method` property and not a `method_name` property.