### PR TITLE
Fix and refactor imports

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -1,14 +1,8 @@
 import enum
 import threading
 import typing
-import sys
 from concurrent import futures
 from types import TracebackType
-if sys.version_info[:2] >= (3, 8):
-    from typing import Literal
-else:
-    # Python 3.7 and earlier
-    from typing_extensions import Literal
 
 __version__: str
 

--- a/grpc_reflection-stubs/v1alpha/reflection.pyi
+++ b/grpc_reflection-stubs/v1alpha/reflection.pyi
@@ -10,5 +10,5 @@ class ReflectionServicer(BaseReflectionServicer):
     def ServerReflectionInfo(self, request_iterator: Iterable[_reflection_pb2.ServerReflectionRequest], context: ServicerContext) -> None:
         ...
 
-def enable_server_reflection(service_names: List[str], server: grpc.Server, pool: Optional[descriptor_pool.DescriptorPool] = ...) -> None:
+def enable_server_reflection(service_names: List[str], server: Server, pool: Optional[descriptor_pool.DescriptorPool] = ...) -> None:
     ...

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from distutils.core import setup
 __version__ = "1.24.11"
 
 dependencies = [
-    "typing-extensions; python_version<'3.8'",
     'grpcio',
 ]
 


### PR DESCRIPTION
## Description of change

When installing this package in my library, I noticed that the server of the reflection stubs has an `Unknown` type. This was caused by a wrongly assigned import. During this fix, I noticed that the current version of this package uses no Literal and this was the only reason the `typing-extension` package was listed as a dependency. I removed those from the package. Should the need for Literal types arise later on, they can easily be added back. In the meantime, we get a "slimmer" package. In the same stub, I could also remove the `sys` import since it was not used.

## Minimum Reproducible Example

An example is not necessary here as there was no "issue" here. I am not adding/altering any stubs, but only corrected some imports. So no change of functionality here.

## Checklist:

- [x] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [x] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
