### PR TITLE
Add partial aio typing stubs

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -6,6 +6,15 @@ from types import TracebackType
 
 __version__: str
 
+# This class encodes an uninhabited type, requiring use of explicit casts or ignores
+# in order to satisfy type checkers. This allows grpc-stubs to add proper stubs
+# later, allowing those overrides to be removed.
+# The alternative is typing.Any, but a future replacement of Any with a proper type
+# would result in type errors where previously the type checker was happy, which
+# we want to avoid. Forcing the user to use overrides provides forwards-compatibility.
+class _PartialStubMustCastOrIgnore:
+    pass
+
 
 # XXX: Early attempts to tame this used literals for all the keys (gRPC is
 # a bit segfaulty and doesn't adequately validate the option keys), but that

--- a/grpc-stubs/aio.pyi
+++ b/grpc-stubs/aio.pyi
@@ -45,6 +45,9 @@ def server(
 
 """Channel Object"""
 
+# XXX: The docs suggest these type signatures for aio, but not for non-async,
+# and it's unclear why;
+# https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Channel.stream_stream
 RequestSerializer = typing.Callable[[typing.Any], bytes]
 ResponseDeserializer = typing.Callable[[bytes], typing.Any]
 
@@ -111,7 +114,7 @@ class Server:
 """Client-Side Context"""
 
 DoneCallbackType = typing.Callable[[typing.Any], None]
-EOFType = _PartialStubMustCastOrIgnore
+EOFType = object
 
 class RpcContext:
     def cancelled(self) -> bool: ...

--- a/grpc-stubs/aio.pyi
+++ b/grpc-stubs/aio.pyi
@@ -3,6 +3,7 @@ from concurrent import futures
 from types import TracebackType
 from . import (
     _Options,
+    _PartialStubMustCastOrIgnore,
     Compression,
     GenericRpcHandler,
     ServerCredentials,
@@ -13,8 +14,7 @@ from . import (
 
 """Create Client"""
 
-# FIXME
-ClientInterceptor = typing.Any
+ClientInterceptor = _PartialStubMustCastOrIgnore
 
 def insecure_channel(
     target: str,
@@ -32,10 +32,12 @@ def secure_channel(
 
 """Create Server"""
 
+ServerInterceptor = _PartialStubMustCastOrIgnore
+
 def server(
     migration_thread_pool: typing.Optional[futures.Executor] = None,
     handlers: typing.Optional[typing.Sequence[GenericRpcHandler]] = None,
-    interceptors: typing.Optional[typing.Sequence[typing.Any]] = None,
+    interceptors: typing.Optional[typing.Sequence[ServerInterceptor]] = None,
     options: typing.Optional[_Options] = None,
     maximum_concurrent_rpcs: typing.Optional[int] = None,
     compression: typing.Optional[Compression] = None,
@@ -109,8 +111,7 @@ class Server:
 """Client-Side Context"""
 
 DoneCallbackType = typing.Callable[[typing.Any], None]
-# FIXME
-EOFType = typing.Any
+EOFType = _PartialStubMustCastOrIgnore
 
 class RpcContext:
     def cancelled(self) -> bool: ...

--- a/grpc-stubs/aio.pyi
+++ b/grpc-stubs/aio.pyi
@@ -1,0 +1,258 @@
+import typing
+from concurrent import futures
+from types import TracebackType
+from . import (
+    _Options,
+    Compression,
+    GenericRpcHandler,
+    ServerCredentials,
+    StatusCode,
+    ChannelCredentials,
+    CallCredentials,
+)
+
+"""Create Client"""
+
+# FIXME
+ClientInterceptor = typing.Any
+
+def insecure_channel(
+    target: str,
+    options: typing.Optional[_Options] = None,
+    compression: typing.Optional[Compression] = None,
+    interceptors: typing.Optional[typing.Sequence[ClientInterceptor]] = None,
+) -> Channel: ...
+def secure_channel(
+    target: str,
+    credentials: ChannelCredentials,
+    options: typing.Optional[_Options] = None,
+    compression: typing.Optional[Compression] = None,
+    interceptors: typing.Optional[typing.Sequence[ClientInterceptor]] = None,
+) -> Channel: ...
+
+"""Create Server"""
+
+def server(
+    migration_thread_pool: typing.Optional[futures.Executor] = None,
+    handlers: typing.Optional[typing.Sequence[GenericRpcHandler]] = None,
+    interceptors: typing.Optional[typing.Sequence[typing.Any]] = None,
+    options: typing.Optional[_Options] = None,
+    maximum_concurrent_rpcs: typing.Optional[int] = None,
+    compression: typing.Optional[Compression] = None,
+) -> Server: ...
+
+"""Channel Object"""
+
+RequestSerializer = typing.Callable[[typing.Any], bytes]
+ResponseDeserializer = typing.Callable[[bytes], typing.Any]
+
+class Channel:
+    async def close(self, grace: typing.Optional[float]) -> None: ...
+    def stream_stream(
+        self,
+        method: str,
+        request_serializer: typing.Optional[RequestSerializer],
+        response_deserializer: typing.Optional[ResponseDeserializer],
+    ) -> StreamStreamMultiCallable: ...
+    def stream_unary(
+        self,
+        method: str,
+        request_serializer: typing.Optional[RequestSerializer],
+        response_deserializer: typing.Optional[ResponseDeserializer],
+    ) -> StreamUnaryMultiCallable: ...
+    def unary_stream(
+        self,
+        method: str,
+        request_serializer: typing.Optional[RequestSerializer],
+        response_deserializer: typing.Optional[ResponseDeserializer],
+    ) -> UnaryStreamMultiCallable: ...
+    def unary_unary(
+        self,
+        method: str,
+        request_serializer: typing.Optional[RequestSerializer],
+        response_deserializer: typing.Optional[ResponseDeserializer],
+    ) -> UnaryUnaryMultiCallable: ...
+    async def __aenter__(self) -> Channel: ...
+    async def __aexit__(
+        self,
+        exc_type: typing.Optional[typing.Type[BaseException]],
+        exc_val: typing.Optional[BaseException],
+        exc_tb: typing.Optional[TracebackType],
+    ) -> typing.Optional[bool]: ...
+    async def channel_ready(self) -> None: ...
+
+"""Server Object"""
+
+class Server:
+    def add_generic_rpc_handlers(
+        self,
+        generic_rpc_handlers: typing.Iterable[GenericRpcHandler],
+    ) -> None: ...
+
+    # Returns an integer port on which server will accept RPC requests.
+    def add_insecure_port(self, address: str) -> int: ...
+
+    # Returns an integer port on which server will accept RPC requests.
+    def add_secure_port(
+        self, address: str, server_credentials: ServerCredentials
+    ) -> int: ...
+    async def start(self) -> None: ...
+
+    # Grace period is in seconds.
+    async def stop(self, grace: typing.Optional[float] = None) -> None: ...
+
+    # Returns a bool indicates if the operation times out. Timeout is in seconds.
+    async def wait_for_termination(
+        self, timeout: typing.Optional[float] = None
+    ) -> bool: ...
+
+"""Client-Side Context"""
+
+DoneCallbackType = typing.Callable[[typing.Any], None]
+# FIXME
+EOFType = typing.Any
+
+class RpcContext:
+    def cancelled(self) -> bool: ...
+    def done(self) -> bool: ...
+    def time_remaining(self) -> typing.Optional[float]: ...
+    def cancel(self) -> bool: ...
+    def add_done_callback(self, callback: DoneCallbackType) -> None: ...
+
+class Call(RpcContext):
+    async def initial_metadata(self) -> Metadata: ...
+    async def trailing_metadata(self) -> Metadata: ...
+    async def code(self) -> StatusCode: ...
+    async def details(self) -> str: ...
+    async def wait_for_connection(self) -> None: ...
+
+class UnaryUnaryCall(typing.Generic[TRequest, TResponse], Call):
+    def __await__(self) -> typing.Generator[None, None, TResponse]: ...
+
+class UnaryStreamCall(typing.Generic[TRequest, TResponse], Call):
+    def __aiter__(self) -> typing.AsyncIterator[TResponse]: ...
+    async def read(self) -> typing.Union[EOFType, TResponse]: ...
+
+class StreamUnaryCall(typing.Generic[TRequest, TResponse], Call):
+    async def write(self, request: TRequest) -> None: ...
+    async def done_writing(self) -> None: ...
+    def __await__(self) -> typing.Generator[None, None, TResponse]: ...
+
+class StreamStreamCall(typing.Generic[TRequest, TResponse], Call):
+    def __aiter__(self) -> typing.AsyncIterator[TResponse]: ...
+    async def read(self) -> typing.Union[EOFType, TResponse]: ...
+    async def write(self, request: TRequest) -> None: ...
+    async def done_writing(self) -> None: ...
+
+TRequest = typing.TypeVar("TRequest")
+TResponse = typing.TypeVar("TResponse")
+
+"""Service-Side Context"""
+
+class ServicerContext(typing.Generic[TRequest, TResponse]):
+    async def read(self) -> TRequest: ...
+    async def write(self, message: TResponse) -> None: ...
+    async def send_initial_metadata(self, initial_metadata: MetadataType) -> None: ...
+    async def abort(
+        self,
+        code: StatusCode,
+        details: str = "",
+        trailing_metadata: MetadataType = tuple(),
+    ) -> typing.NoReturn: ...
+    def set_trailing_metadata(self, trailing_metadata: MetadataType) -> None: ...
+    def invocation_metadata(self) -> typing.Optional[Metadata]: ...
+    def set_code(self, code: StatusCode) -> None: ...
+    def set_details(self, details: str) -> None: ...
+    def set_compression(self, compression: Compression) -> None: ...
+    def disable_next_message_compression(self) -> None: ...
+    def peer(self) -> str: ...
+    def peer_identities(self) -> typing.Optional[typing.Iterable[bytes]]: ...
+    def peer_identity_key(self) -> typing.Optional[str]: ...
+    def auth_context(self) -> typing.Mapping[str, typing.Iterable[bytes]]: ...
+    def time_remaining(self) -> float: ...
+    def trailing_metadata(self) -> Metadata: ...
+    def code(self) -> StatusCode: ...
+    def details(self) -> str: ...
+    def cancelled(self) -> bool: ...
+    def done(self) -> bool: ...
+
+"""Multi-Callable Interfaces"""
+
+class UnaryUnaryMultiCallable(typing.Generic[TRequest, TResponse]):
+    def __call__(
+        self,
+        request: TRequest,
+        timeout: typing.Optional[int] = None,
+        metadata: typing.Optional[MetadataType] = None,
+        credentials: typing.Optional[CallCredentials] = None,
+        # FIXME: optional bool seems weird, but that's what the docs suggest
+        wait_for_ready: typing.Optional[bool] = None,
+        compression: typing.Optional[Compression] = None,
+    ) -> UnaryUnaryCall[TRequest, TResponse]: ...
+
+class UnaryStreamMultiCallable(typing.Generic[TRequest, TResponse]):
+    def __call__(
+        self,
+        request: TRequest,
+        timeout: typing.Optional[float] = None,
+        metadata: typing.Optional[MetadataType] = None,
+        credentials: typing.Optional[CallCredentials] = None,
+        # FIXME: optional bool seems weird, but that's what the docs suggest
+        wait_for_ready: typing.Optional[bool] = None,
+        compression: typing.Optional[Compression] = None,
+    ) -> UnaryStreamCall[TRequest, TResponse]: ...
+
+class StreamUnaryMultiCallable(typing.Generic[TRequest, TResponse]):
+    def __call__(
+        self,
+        request_iterator: typing.Optional[
+            typing.Union[typing.AsyncIterator[TRequest], typing.Iterator[TRequest]]
+        ],
+        timeout: typing.Optional[float] = None,
+        metadata: typing.Optional[MetadataType] = None,
+        credentials: typing.Optional[CallCredentials] = None,
+        # FIXME: optional bool seems weird, but that's what the docs suggest
+        wait_for_ready: typing.Optional[bool] = None,
+        compression: typing.Optional[Compression] = None,
+    ) -> StreamUnaryCall[TRequest, TResponse]: ...
+
+class StreamStreamMultiCallable(typing.Generic[TRequest, TResponse]):
+    def __call__(
+        self,
+        request_iterator: typing.Optional[
+            typing.Union[typing.AsyncIterator[TRequest], typing.Iterator[TRequest]]
+        ],
+        timeout: typing.Optional[float] = None,
+        metadata: typing.Optional[MetadataType] = None,
+        credentials: typing.Optional[CallCredentials] = None,
+        # FIXME: optional bool seems weird, but that's what the docs suggest
+        wait_for_ready: typing.Optional[bool] = None,
+        compression: typing.Optional[Compression] = None,
+    ) -> StreamStreamCall[TRequest, TResponse]: ...
+
+"""Metadata"""
+
+MetadataKey = str
+MetadataValue = typing.Union[str, bytes]
+MetadatumType = typing.Tuple[MetadataKey, MetadataValue]
+MetadataType = typing.Union[Metadata, typing.Sequence[MetadatumType]]
+
+class Metadata(typing.Mapping):
+    def __init__(self, *args: typing.Tuple[MetadataKey, MetadataValue]) -> None: ...
+    @classmethod
+    def from_tuple(
+        cls, raw_metadata: typing.Tuple[MetadataKey, MetadataValue]
+    ) -> Metadata: ...
+    def add(self, key: MetadataKey, value: MetadataValue) -> None: ...
+    def __len__(self) -> int: ...
+    def __getitem__(self, key: MetadataKey) -> MetadataValue: ...
+    def __setitem__(self, key: MetadataKey, value: MetadataValue) -> None: ...
+    def __delitem__(self, key: MetadataKey) -> None: ...
+    def delete_all(self, key: MetadataKey) -> None: ...
+    def __iter__(self) -> typing.Iterator[typing.Tuple[MetadataKey, MetadataValue]]: ...
+    def get_all(self, key: MetadataKey) -> typing.List[MetadataValue]: ...
+    def set_all(self, key: MetadataKey, values: typing.List[MetadataValue]) -> None: ...
+    def __contains__(self, key: object) -> bool: ...
+    def __eq__(self, other: typing.Any) -> bool: ...
+    def __add__(self, other: typing.Any) -> Metadata: ...
+    def __repr__(self) -> str: ...

--- a/grpc-stubs/py.typed
+++ b/grpc-stubs/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -123,3 +123,35 @@
     for resp in stub.StreamStream(iter([req])):
       pass
     reveal_type(resp)  # N: Revealed type is "main.DummyReply"
+
+- case: aio_multi_callable
+  main: |
+    import grpc.aio
+
+    class DummyRequest:
+      pass
+
+    class DummyReply:
+      pass
+
+    class DummyServiceStub:
+      UnaryUnary: grpc.aio.UnaryUnaryMultiCallable[DummyRequest, DummyReply]
+      UnaryStream: grpc.aio.UnaryStreamMultiCallable[DummyRequest, DummyReply]
+      StreamUnary: grpc.aio.StreamUnaryMultiCallable[DummyRequest, DummyReply]
+      StreamStream: grpc.aio.StreamStreamMultiCallable[DummyRequest, DummyReply]
+
+    stub = DummyServiceStub()
+    req = DummyRequest()
+
+    async def async_context() -> None:
+      reveal_type(await stub.UnaryUnary(req))  # N: Revealed type is "main.DummyReply"
+
+      async for resp in stub.UnaryStream(req):
+        pass
+      reveal_type(resp)  # N: Revealed type is "main.DummyReply"
+
+      reveal_type(await stub.StreamUnary(iter([req])))  # N: Revealed type is "main.DummyReply"
+
+      async for resp in stub.StreamStream(iter([req])):
+        pass
+      reveal_type(resp)  # N: Revealed type is "main.DummyReply"

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -85,3 +85,34 @@
     reveal_type(creds)  # N: Revealed type is "grpc.ChannelCredentials"
     screds = grpc.xds_server_credentials(grpc.insecure_server_credentials())
     reveal_type(screds)  # N: Revealed type is "grpc.ServerCredentials"
+
+- case: multi_callable
+  main: |
+    import grpc
+
+    class DummyRequest:
+      pass
+
+    class DummyReply:
+      pass
+
+    class DummyServiceStub:
+      UnaryUnary: grpc.UnaryUnaryMultiCallable[DummyRequest, DummyReply]
+      UnaryStream: grpc.UnaryStreamMultiCallable[DummyRequest, DummyReply]
+      StreamUnary: grpc.StreamUnaryMultiCallable[DummyRequest, DummyReply]
+      StreamStream: grpc.StreamStreamMultiCallable[DummyRequest, DummyReply]
+
+    stub = DummyServiceStub()
+    req = DummyRequest()
+
+    reveal_type(stub.UnaryUnary(req))  # N: Revealed type is "main.DummyReply"
+
+    for resp in stub.UnaryStream(req):
+      pass
+    reveal_type(resp)  # N: Revealed type is "main.DummyReply"
+
+    reveal_type(stub.StreamUnary(iter([req])))  # N: Revealed type is "main.DummyReply"
+
+    for resp in stub.StreamStream(iter([req])):
+      pass
+    reveal_type(resp)  # N: Revealed type is "main.DummyReply"

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -155,3 +155,14 @@
       async for resp in stub.StreamStream(iter([req])):
         pass
       reveal_type(resp)  # N: Revealed type is "main.DummyReply"
+
+- case: aio_interceptors_casts
+  main: |
+    import typing
+    import grpc.aio
+
+    client_interceptors = [typing.cast(grpc.aio.ClientInterceptor, "interceptor")]
+    grpc.aio.insecure_channel("target", interceptors=client_interceptors)
+
+    server_interceptors = [typing.cast(grpc.aio.ServerInterceptor, "interceptor")]
+    grpc.aio.server(interceptors=server_interceptors)

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -5,6 +5,13 @@
     reveal_type(Channel())  # N: Revealed type is "grpc.Channel"
     reveal_type(Server())   # N: Revealed type is "grpc.Server"
 
+- case: grpc_aio
+  main: |
+    from grpc.aio import Channel, Server
+
+    reveal_type(Channel())  # N: Revealed type is "grpc.aio.Channel"
+    reveal_type(Server())   # N: Revealed type is "grpc.aio.Server"
+
 - case: grpc_status
   main: |
     from grpc import Status


### PR DESCRIPTION
## Description of change

Added typing stubs for:
* Multi-callable
* Server
* Channel

This should be sufficient for basic mypy-protobuf usage.

Also added a test for multi-callable usage, since that's the gnarliest part.

## Minimum Reproducible Example

> Pull requests will not be accepted without minimum reproducible examples. "Reproducible" in this case
> means the following is provided, in separate `<details>` blocks, using as few files as possible. Gists
> and links to other repositories are not acceptable as an MRE. Pull requests without an MRE will be
> immediately closed.
>
> - One or more python files containing reproducing code.
> - Full set of shell commands (POSIX shell or bash only) required to create a venv, install
>   dependencies, and generate proto.
>
> This is necessary due to the large number of PRs that have been missing tests or examples, which
> causes knock-on effects for all users.

<details>
<summary>dummy_pb2_grpc.py</summary>

```py
# Generated by the gRPC Python protocol compiler plugin. DO NOT EDIT!
"""Client and server classes corresponding to protobuf-defined services."""
import grpc

import dummy_pb2 as testproto_dot_grpc_dot_dummy__pb2


class DummyServiceStub(object):
    """DummyService
    """

    def __init__(self, channel):
        """Constructor.

        Args:
            channel: A grpc.Channel.
        """
        self.UnaryUnary = channel.unary_unary(
                '/dummy.DummyService/UnaryUnary',
                request_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
                response_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
                )
        self.UnaryStream = channel.unary_stream(
                '/dummy.DummyService/UnaryStream',
                request_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
                response_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
                )
        self.StreamUnary = channel.stream_unary(
                '/dummy.DummyService/StreamUnary',
                request_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
                response_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
                )
        self.StreamStream = channel.stream_stream(
                '/dummy.DummyService/StreamStream',
                request_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
                response_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
                )


class DummyServiceServicer(object):
    """DummyService
    """

    def UnaryUnary(self, request, context):
        """UnaryUnary
        """
        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
        context.set_details('Method not implemented!')
        raise NotImplementedError('Method not implemented!')

    def UnaryStream(self, request, context):
        """UnaryStream
        """
        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
        context.set_details('Method not implemented!')
        raise NotImplementedError('Method not implemented!')

    def StreamUnary(self, request_iterator, context):
        """StreamUnary
        """
        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
        context.set_details('Method not implemented!')
        raise NotImplementedError('Method not implemented!')

    def StreamStream(self, request_iterator, context):
        """StreamStream
        """
        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
        context.set_details('Method not implemented!')
        raise NotImplementedError('Method not implemented!')


def add_DummyServiceServicer_to_server(servicer, server):
    rpc_method_handlers = {
            'UnaryUnary': grpc.unary_unary_rpc_method_handler(
                    servicer.UnaryUnary,
                    request_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.FromString,
                    response_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.SerializeToString,
            ),
            'UnaryStream': grpc.unary_stream_rpc_method_handler(
                    servicer.UnaryStream,
                    request_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.FromString,
                    response_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.SerializeToString,
            ),
            'StreamUnary': grpc.stream_unary_rpc_method_handler(
                    servicer.StreamUnary,
                    request_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.FromString,
                    response_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.SerializeToString,
            ),
            'StreamStream': grpc.stream_stream_rpc_method_handler(
                    servicer.StreamStream,
                    request_deserializer=testproto_dot_grpc_dot_dummy__pb2.DummyRequest.FromString,
                    response_serializer=testproto_dot_grpc_dot_dummy__pb2.DummyReply.SerializeToString,
            ),
    }
    generic_handler = grpc.method_handlers_generic_handler(
            'dummy.DummyService', rpc_method_handlers)
    server.add_generic_rpc_handlers((generic_handler,))


 # This class is part of an EXPERIMENTAL API.
class DummyService(object):
    """DummyService
    """

    @staticmethod
    def UnaryUnary(request,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            insecure=False,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.unary_unary(request, target, '/dummy.DummyService/UnaryUnary',
            testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
            testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
            options, channel_credentials,
            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def UnaryStream(request,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            insecure=False,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.unary_stream(request, target, '/dummy.DummyService/UnaryStream',
            testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
            testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
            options, channel_credentials,
            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def StreamUnary(request_iterator,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            insecure=False,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.stream_unary(request_iterator, target, '/dummy.DummyService/StreamUnary',
            testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
            testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
            options, channel_credentials,
            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

    @staticmethod
    def StreamStream(request_iterator,
            target,
            options=(),
            channel_credentials=None,
            call_credentials=None,
            insecure=False,
            compression=None,
            wait_for_ready=None,
            timeout=None,
            metadata=None):
        return grpc.experimental.stream_stream(request_iterator, target, '/dummy.DummyService/StreamStream',
            testproto_dot_grpc_dot_dummy__pb2.DummyRequest.SerializeToString,
            testproto_dot_grpc_dot_dummy__pb2.DummyReply.FromString,
            options, channel_credentials,
            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

```

</details>

<details>
<summary>dummy_pb2_grpc.pyi</summary>

```py

"""
@generated by mypy-protobuf.  Do not edit manually!
isort:skip_file
https://github.com/vmagamedov/grpclib/blob/master/tests/dummy.proto"""
import abc
import grpc
import grpc.aio
import dummy_pb2
import typing

_T = typing.TypeVar('_T')

class _MaybeAsyncIterator(typing.AsyncIterator[_T], typing.Iterator[_T], metaclass=abc.ABCMeta):
    ...

class _ServicerContext(grpc.ServicerContext, grpc.aio.ServicerContext):  # type: ignore
    ...

class DummyServiceStub:
    """DummyService"""

    def __init__(self, channel: typing.Union[grpc.Channel, grpc.aio.Channel]) -> None: ...
    UnaryUnary: grpc.UnaryUnaryMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """UnaryUnary"""
    UnaryStream: grpc.UnaryStreamMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """UnaryStream"""
    StreamUnary: grpc.StreamUnaryMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """StreamUnary"""
    StreamStream: grpc.StreamStreamMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """StreamStream"""

class DummyServiceAsyncStub:
    """DummyService"""

    UnaryUnary: grpc.aio.UnaryUnaryMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """UnaryUnary"""
    UnaryStream: grpc.aio.UnaryStreamMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """UnaryStream"""
    StreamUnary: grpc.aio.StreamUnaryMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """StreamUnary"""
    StreamStream: grpc.aio.StreamStreamMultiCallable[
        dummy_pb2.DummyRequest,
        dummy_pb2.DummyReply,
    ]
    """StreamStream"""

class DummyServiceServicer(metaclass=abc.ABCMeta):
    """DummyService"""

    @abc.abstractmethod
    def UnaryUnary(
        self,
        request: dummy_pb2.DummyRequest,
        context: _ServicerContext,
    ) -> typing.Union[dummy_pb2.DummyReply, typing.Awaitable[dummy_pb2.DummyReply]]:
        """UnaryUnary"""
    @abc.abstractmethod
    def UnaryStream(
        self,
        request: dummy_pb2.DummyRequest,
        context: _ServicerContext,
    ) -> typing.Union[typing.Iterator[dummy_pb2.DummyReply], typing.AsyncIterator[dummy_pb2.DummyReply]]:
        """UnaryStream"""
    @abc.abstractmethod
    def StreamUnary(
        self,
        request_iterator: _MaybeAsyncIterator[dummy_pb2.DummyRequest],
        context: _ServicerContext,
    ) -> typing.Union[dummy_pb2.DummyReply, typing.Awaitable[dummy_pb2.DummyReply]]:
        """StreamUnary"""
    @abc.abstractmethod
    def StreamStream(
        self,
        request_iterator: _MaybeAsyncIterator[dummy_pb2.DummyRequest],
        context: _ServicerContext,
    ) -> typing.Union[typing.Iterator[dummy_pb2.DummyReply], typing.AsyncIterator[dummy_pb2.DummyReply]]:
        """StreamStream"""

def add_DummyServiceServicer_to_server(servicer: DummyServiceServicer, server: typing.Union[grpc.Server, grpc.aio.Server]) -> None: ...

```

</details>

<details>
<summary>dummy_pb2.py</summary>

```py
# -*- coding: utf-8 -*-
# Generated by the protocol buffer compiler.  DO NOT EDIT!
# source: testproto/grpc/dummy.proto
"""Generated protocol buffer code."""
from google.protobuf.internal import builder as _builder
from google.protobuf import descriptor as _descriptor
from google.protobuf import descriptor_pool as _descriptor_pool
from google.protobuf import symbol_database as _symbol_database
# @@protoc_insertion_point(imports)

_sym_db = _symbol_database.Default()




DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1atestproto/grpc/dummy.proto\x12\x05\x64ummy\"\x1d\n\x0c\x44ummyRequest\x12\r\n\x05value\x18\x01 \x01(\t\"\x1b\n\nDummyReply\x12\r\n\x05value\x18\x01 \x01(\t2\xfa\x01\n\x0c\x44ummyService\x12\x36\n\nUnaryUnary\x12\x13.dummy.DummyRequest\x1a\x11.dummy.DummyReply\"\x00\x12\x39\n\x0bUnaryStream\x12\x13.dummy.DummyRequest\x1a\x11.dummy.DummyReply\"\x00\x30\x01\x12\x39\n\x0bStreamUnary\x12\x13.dummy.DummyRequest\x1a\x11.dummy.DummyReply\"\x00(\x01\x12<\n\x0cStreamStream\x12\x13.dummy.DummyRequest\x1a\x11.dummy.DummyReply\"\x00(\x01\x30\x01\x62\x06proto3')

_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'dummy_pb2', globals())
if _descriptor._USE_C_DESCRIPTORS == False:

  DESCRIPTOR._options = None
  _DUMMYREQUEST._serialized_start=37
  _DUMMYREQUEST._serialized_end=66
  _DUMMYREPLY._serialized_start=68
  _DUMMYREPLY._serialized_end=95
  _DUMMYSERVICE._serialized_start=98
  _DUMMYSERVICE._serialized_end=348
# @@protoc_insertion_point(module_scope)

```

</details>

<details>
<summary>dummy_pb2.pyi</summary>

```
"""
@generated by mypy-protobuf.  Do not edit manually!
isort:skip_file
https://github.com/vmagamedov/grpclib/blob/master/tests/dummy.proto"""
import builtins
import google.protobuf.descriptor
import google.protobuf.message
import sys

if sys.version_info >= (3, 8):
    import typing as typing_extensions
else:
    import typing_extensions

DESCRIPTOR: google.protobuf.descriptor.FileDescriptor

@typing_extensions.final
class DummyRequest(google.protobuf.message.Message):
    DESCRIPTOR: google.protobuf.descriptor.Descriptor

    VALUE_FIELD_NUMBER: builtins.int
    value: builtins.str
    def __init__(
        self,
        *,
        value: builtins.str = ...,
    ) -> None: ...
    def ClearField(self, field_name: typing_extensions.Literal["value", b"value"]) -> None: ...

global___DummyRequest = DummyRequest

@typing_extensions.final
class DummyReply(google.protobuf.message.Message):
    DESCRIPTOR: google.protobuf.descriptor.Descriptor

    VALUE_FIELD_NUMBER: builtins.int
    value: builtins.str
    def __init__(
        self,
        *,
        value: builtins.str = ...,
    ) -> None: ...
    def ClearField(self, field_name: typing_extensions.Literal["value", b"value"]) -> None: ...

global___DummyReply = DummyReply

```

</details>

<details>
<summary>test_grpc_async_usage.py</summary>

```py
import typing
import pytest

import grpc
import dummy_pb2, dummy_pb2_grpc

ADDRESS = "localhost:22223"


class Servicer(dummy_pb2_grpc.DummyServiceServicer):
    async def UnaryUnary(
        self,
        request: dummy_pb2.DummyRequest,
        context: grpc.aio.ServicerContext,
    ) -> dummy_pb2.DummyReply:
        return dummy_pb2.DummyReply(value=request.value[::-1])

    async def UnaryStream(
        self,
        request: dummy_pb2.DummyRequest,
        context: grpc.aio.ServicerContext,
    ) -> typing.AsyncIterator[dummy_pb2.DummyReply]:
        for char in request.value:
            yield dummy_pb2.DummyReply(value=char)

    async def StreamUnary(
        self,
        request: typing.AsyncIterator[dummy_pb2.DummyRequest],
        context: grpc.aio.ServicerContext,
    ) -> dummy_pb2.DummyReply:
        values = [data.value async for data in request]
        return dummy_pb2.DummyReply(value="".join(values))

    async def StreamStream(
        self,
        request: typing.AsyncIterator[dummy_pb2.DummyRequest],
        context: grpc.ServicerContext,
    ) -> typing.AsyncIterator[dummy_pb2.DummyReply]:
        async for data in request:
            yield dummy_pb2.DummyReply(value=data.value.upper())


def make_server() -> grpc.aio.Server:
    server = grpc.aio.server()
    servicer = Servicer()
    server.add_insecure_port(ADDRESS)
    dummy_pb2_grpc.add_DummyServiceServicer_to_server(servicer, server)
    return server


@pytest.mark.asyncio
async def test_grpc() -> None:
    server = make_server()
    await server.start()
    async with grpc.aio.insecure_channel(ADDRESS) as channel:
        client: dummy_pb2_grpc.DummyServiceAsyncStub = dummy_pb2_grpc.DummyServiceStub(channel)  # type: ignore
        request = dummy_pb2.DummyRequest(value="cprg")
        result1 = await client.UnaryUnary(request)
        result2 = client.UnaryStream(dummy_pb2.DummyRequest(value=result1.value))
        result2_list = [r async for r in result2]
        assert len(result2_list) == 4
        result3 = client.StreamStream(dummy_pb2.DummyRequest(value=part.value) for part in result2_list)
        result3_list = [r async for r in result3]
        assert len(result3_list) == 4
        result4 = await client.StreamUnary(dummy_pb2.DummyRequest(value=part.value) for part in result3_list)
        assert result4.value == "GRPC"

    await server.stop(None)

```

</details>

<details>
<summary>run.sh</summary>

```sh
#!/usr/bin/env bash
set -o errexit -o nounset -o pipefail
python -m venv venv
source ./venv/bin/activate
pip install \
    protobuf==4.21.9 \
    pytest==7.2.0 \
    pytest-asyncio==0.20.3 \
    grpcio-tools==1.50.0 \
    mypy \
    types-protobuf==4.21.0.1

python -m pytest test_grpc_async_usage.py
mypy test_grpc_async_usage.py

```

</details>

## Checklist:

- [x] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [x] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
