### PR TITLE
Fix return type from intercept_service

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -616,7 +616,7 @@ class ServerInterceptor(typing.Generic[TRequest, TResponse]):
             typing.Optional[RpcMethodHandler[TRequest, TResponse]]
         ],
         handler_call_details: HandlerCallDetails,
-    ) -> RpcMethodHandler[TRequest, TResponse]:
+    ) -> typing.Optional[RpcMethodHandler[TRequest, TResponse]]:
         ...
 
 

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -222,3 +222,15 @@
     server = typing.cast(aio.Server, None)
     enable_server_reflection(["foo"], server, None)
 
+- case: server_interceptor
+  main: |
+    import typing
+    import grpc
+    
+    class NoopInterceptor(grpc.ServerInterceptor):
+        def intercept_service(
+            self,
+            continuation: typing.Callable[[grpc.HandlerCallDetails], typing.Optional[grpc.RpcMethodHandler]],
+            handler_call_details: grpc.HandlerCallDetails,
+        ) -> typing.Optional[grpc.RpcMethodHandler]:
+            return continuation(handler_call_details)


### PR DESCRIPTION
## Description of change

Updating return type for `ServerInterceptor.intercept_service`, according to the [gRPC documentation](https://grpc.github.io/grpc/python/grpc.html#grpc.ServerInterceptor.intercept_service) this can also return `None`. This is the documentation for the return type:

> An RpcMethodHandler with which the RPC may be serviced if the interceptor chooses to service this RPC, or None otherwise.

## Minimum Reproducible Example

This is a one-line change and I believe the provided typing test is sufficient.

## Checklist:

- [ ] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
  - [x] **OR** I believe my contribution is minor enough that a typing test is sufficient.
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [x] I have removed any code generation notices from anything seeded using `mypy-protobuf`.