### PR TITLE
Accept any Iterable for service_names

### DIFF
--- a/grpc_reflection-stubs/v1alpha/reflection.pyi
+++ b/grpc_reflection-stubs/v1alpha/reflection.pyi
@@ -20,7 +20,7 @@ class ReflectionServicer(BaseReflectionServicer):
         ...
 
 def enable_server_reflection(
-    service_names: typing.List[str],
+    service_names: typing.Iterable[str],
     server: AnyServer,
     pool: typing.Optional[descriptor_pool.DescriptorPool] = ...,
 ) -> None:


### PR DESCRIPTION
## Description of change

Passing a `set` works for me locally, but then Mypy gets mad because of this type hint.

## Checklist:

- [ ] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
  - [x] **OR** I believe my contribution is minor enough that a typing test is sufficient.
- [ ] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [ ] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
