### PR TITLE
Fixing typing for namespaced aio import

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -4,6 +4,8 @@ import typing
 from concurrent import futures
 from types import ModuleType, TracebackType
 
+from grpc import aio
+
 __version__: str
 
 # This class encodes an uninhabited type, requiring use of explicit casts or ignores

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -12,6 +12,13 @@
     reveal_type(Channel())  # N: Revealed type is "grpc.aio.Channel"
     reveal_type(Server())   # N: Revealed type is "grpc.aio.Server"
 
+- case: grpc_aio_package
+  main: |
+    import grpc
+
+    reveal_type(grpc.aio.Channel())  # N: Revealed type is "grpc.aio.Channel"
+    reveal_type(grpc.aio.Server())   # N: Revealed type is "grpc.aio.Server"
+
 - case: grpc_status
   main: |
     from grpc import Status


### PR DESCRIPTION
## Description of change

## Minimum Reproducible Example

> Pull requests of any significance *will not be accepted* without minimum reproducible examples.
> If your contribution is small enough (a few lines tops), a typing test might be enough, but an MRE might still
> be requested. If in doubt, presume an MRE will be required.
>
> Pull requests where an MRE is requested but not supplied will be closed.
>
> "Reproducible" means you have given me enough materials to exercise runnable code that 
> demonstrates your change, on my local machine, with a minimum of fuss.
> 
> Gists, links to other repositories, or typing tests are not acceptable as an MRE.
> 
> If an MRE is needed (it probably is), the following must be provided, at a minimum, in
> separate `<details>` blocks, using as few files as possible (templates are provided below): 
>
> - One or more python files containing reproducing code.
> - Full set of shell commands (POSIX shell or bash only) required to create a venv, install
>   dependencies, and generate proto.
>
> Please see README.md for the rationale for why this is needed.

<details>
<summary>main.py</summary>

```py
# Full python code to reproduce
if __name__ == "__main__":
    import grpc
    grpc.aio.Channel
```

</details>

<details>
<summary>run.sh</summary>

```sh
#!/usr/bin/env bash
set -o errexit -o nounset -o pipefail
python -m venv venv
source ./venv/bin/activate
pip install grpcio
python main.py
```

</details>

## Checklist:

- [ ] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
  - [x] **OR** I believe my contribution is minor enough that a typing test is sufficient.
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [ ] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
