### PR TITLE
The call-iterator concept is also an iterator

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -510,7 +510,9 @@ class UnaryUnaryClientInterceptor(typing.Generic[TRequest, TResponse]):
 
 
 class CallIterator(typing.Generic[TResponse], Call):
+    """Both a Call for the RPC and an iterator of response values."""
     def __iter__(self) -> typing.Iterator[TResponse]: ...
+    def __next__(self) -> TResponse: ...
 
 
 class UnaryStreamClientInterceptor(typing.Generic[TRequest, TResponse]):

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -239,3 +239,12 @@
     import grpc.aio
     reveal_type(grpc.aio.Channel())  # N: Revealed type is "grpc.aio.Channel"
     reveal_type(grpc.aio.Server())   # N: Revealed type is "grpc.aio.Server"
+
+- case: call-iterator_is_an_iterator
+  main: |
+    import grpc
+    class TestRequest: ...
+    class TestResponse: ...
+    callable: grpc.UnaryStreamMultiCallable[TestRequest, TestResponse]
+    call_iterator = reveal_type(callable(TestRequest())) # N: Revealed type is "grpc.CallIterator[main.TestResponse]"
+    reveal_type(next(call_iterator)) # N: Revealed type is "main.TestResponse"


### PR DESCRIPTION
## Description of change

Fixes #50 by adding `__next__()` as a method on `CallIterator`.

Internally, it seems `grpc._channel._MultiThreadedRendezvous` is used, which also has some other capabilities. However, as they aren't reflected in the documentation and this interface can be defined differently depending on usage, this does seem to be the right change.

## Minimum Reproducible Example

> Pull requests of any significance *will not be accepted* without minimum reproducible examples.
> If your contribution is small enough (a few lines tops), a typing test might be enough, but an MRE might still
> be requested. If in doubt, presume an MRE will be required.
>
> Pull requests where an MRE is requested but not supplied will be closed.
>
> "Reproducible" means you have given me enough materials to exercise runnable code that 
> demonstrates your change, on my local machine, with a minimum of fuss.
> 
> Gists, links to other repositories, or typing tests are not acceptable as an MRE.
> 
> If an MRE is needed (it probably is), the following must be provided, at a minimum, in
> separate `<details>` blocks, using as few files as possible (templates are provided below): 
>
> - One or more python files containing reproducing code.
> - Full set of shell commands (POSIX shell or bash only) required to create a venv, install
>   dependencies, and generate proto.
>
> Please see README.md for the rationale for why this is needed.

<details>
<summary>main.py</summary>

```py
# Full python code to reproduce
if __name__ == "__main__":
    ...
```

</details>

<details>
<summary>run.sh</summary>

```sh
#!/usr/bin/env bash
set -o errexit -o nounset -o pipefail
python -m venv venv
source ./venv/bin/activate
pip install $INSERT_DEPENDENCIES_HERE
python main.py
```

</details>

## Checklist:

- [ ] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
  - [x] **OR** I believe my contribution is minor enough that a typing test is sufficient.
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [ ] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
