### PR TITLE
Fix ClientInterceptor stubs

### DIFF
--- a/grpc-stubs/__init__.pyi
+++ b/grpc-stubs/__init__.pyi
@@ -466,40 +466,21 @@ class CallFuture(Call, Future[TResponse], typing.Generic[TResponse]):
     pass
 
 
-class UnaryUnaryClientInterceptor(typing.Generic[TRequest, TResponse]):
-    def intercept_unary_unary(
-        self,
-
-        # FIXME: decode these cryptic runes to confirm the typing mystery of
-        # this callable's signature that was left for us by past civilisations:
-        #
-        #     continuation – A function that proceeds with the invocation by
-        #     executing the next interceptor in chain or invoking the actual RPC
-        #     on the underlying Channel. It is the interceptor’s responsibility
-        #     to call it if it decides to move the RPC forward. The interceptor
-        #     can use response_future = continuation(client_call_details,
-        #     request) to continue with the RPC. continuation returns an object
-        #     that is both a Call for the RPC and a Future. In the event of RPC
-        #     completion, the return Call-Future’s result value will be the
-        #     response message of the RPC. Should the event terminate with non-OK
-        #     status, the returned Call-Future’s exception value will be an
-        #     RpcError.
-        #
-        continuation: typing.Callable[[ClientCallDetails, TRequest], CallFuture[TResponse]],
-
-        client_call_details: ClientCallDetails,
-
-        request: TRequest,
-
-    ) -> CallFuture[TResponse]:
-        ...
-
-
 class CallIterator(typing.Generic[TResponse], Call):
     def __iter__(self) -> typing.Iterator[TResponse]: ...
 
 
-class UnaryStreamClientInterceptor(typing.Generic[TRequest, TResponse]):
+class UnaryUnaryClientInterceptor:
+    def intercept_unary_unary(
+        self,
+        continuation: typing.Callable[[ClientCallDetails, TRequest], CallFuture[TResponse]],
+        client_call_details: ClientCallDetails,
+        request: TRequest,
+    ) -> CallFuture[TResponse]:
+        ...
+
+
+class UnaryStreamClientInterceptor:
     def intercept_unary_stream(
         self,
         continuation: typing.Callable[[ClientCallDetails, TRequest], CallIterator[TResponse]],
@@ -509,7 +490,7 @@ class UnaryStreamClientInterceptor(typing.Generic[TRequest, TResponse]):
         ...
 
 
-class StreamUnaryClientInterceptor(typing.Generic[TRequest, TResponse]):
+class StreamUnaryClientInterceptor:
     def intercept_stream_unary(
         self,
         continuation: typing.Callable[[ClientCallDetails, typing.Iterator[TRequest]], CallFuture[TResponse]],
@@ -519,7 +500,7 @@ class StreamUnaryClientInterceptor(typing.Generic[TRequest, TResponse]):
         ...
 
 
-class StreamStreamClientInterceptor(typing.Generic[TRequest, TResponse]):
+class StreamStreamClientInterceptor:
     def intercept_stream_stream(
         self,
         continuation: typing.Callable[[ClientCallDetails, typing.Iterator[TRequest]], CallIterator[TResponse]],

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -312,6 +312,71 @@
     server = typing.cast(aio.Server, None)
     enable_server_reflection(["foo"], server, None)
 
+- case: client_interceptors
+  main: |
+    import typing
+    import grpc
+
+    MyRequestT = typing.TypeVar("MyRequestT")
+    MyResponseT = typing.TypeVar("MyResponseT")
+
+    class MyUnaryUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
+      def intercept_unary_unary(
+        self,
+        continuation: typing.Callable[
+          [grpc.ClientCallDetails, MyRequestT],
+          grpc.CallFuture[MyResponseT],
+        ],
+        client_call_details: grpc.ClientCallDetails,
+        request: MyRequestT,
+      ) -> grpc.CallFuture[MyResponseT]:
+        return continuation(client_call_details, request)
+
+    class MyUnaryStreamInterceptor(grpc.UnaryStreamClientInterceptor):
+      def intercept_unary_stream(
+        self,
+        continuation: typing.Callable[
+          [grpc.ClientCallDetails, MyRequestT],
+          grpc.CallIterator[MyResponseT],
+        ],
+        client_call_details: grpc.ClientCallDetails,
+        request: MyRequestT,
+      ) -> grpc.CallIterator[MyResponseT]:
+        return continuation(client_call_details, request)
+
+    class MyStreamUnaryInterceptor(grpc.StreamUnaryClientInterceptor):
+      def intercept_stream_unary(
+        self,
+        continuation: typing.Callable[
+          [grpc.ClientCallDetails, typing.Iterator[MyRequestT]],
+          grpc.CallFuture[MyResponseT],
+        ],
+        client_call_details: grpc.ClientCallDetails,
+        request_iterator: typing.Iterator[MyRequestT],
+      ) -> grpc.CallFuture[MyResponseT]:
+        return continuation(client_call_details, request_iterator)
+
+    class MyStreamStreamInterceptor(grpc.StreamStreamClientInterceptor):
+      def intercept_stream_stream(
+        self,
+        continuation: typing.Callable[
+          [grpc.ClientCallDetails, typing.Iterator[MyRequestT]],
+          grpc.CallIterator[MyResponseT],
+        ],
+        client_call_details: grpc.ClientCallDetails,
+        request_iterator: typing.Iterator[MyRequestT],
+      ) -> grpc.CallIterator[MyResponseT]:
+        return continuation(client_call_details, request_iterator)
+
+    channel = grpc.insecure_channel("target")
+    channel = grpc.intercept_channel(
+      channel,
+      MyUnaryUnaryInterceptor(),
+      MyUnaryStreamInterceptor(),
+      MyStreamUnaryInterceptor(),
+      MyStreamStreamInterceptor(),
+    )
+
 - case: server_interceptor
   main: |
     import typing

--- a/typesafety/test_grpc.yml
+++ b/typesafety/test_grpc.yml
@@ -155,15 +155,106 @@
         pass
       reveal_type(resp)  # N: Revealed type is "main.DummyReply"
 
-- case: aio_interceptors_casts
+- case: aio_client_interceptors
   main: |
     import typing
+    import grpc
     import grpc.aio
 
-    client_interceptors = [typing.cast(grpc.aio.ClientInterceptor, "interceptor")]
+    MyRequestT = typing.TypeVar("MyRequestT")
+    MyResponseT = typing.TypeVar("MyResponseT")
+
+    class MyUnaryUnaryInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
+      async def intercept_unary_unary(
+        self,
+        continuation: typing.Callable[
+          [grpc.aio.ClientCallDetails, MyRequestT],
+          typing.Awaitable[grpc.aio.UnaryUnaryCall[MyRequestT, MyResponseT]],
+        ],
+        client_call_details: grpc.aio.ClientCallDetails,
+        request: MyRequestT,
+      ) -> typing.Union[
+        MyResponseT,
+        grpc.aio.UnaryUnaryCall[MyRequestT, MyResponseT],
+      ]:
+        return await continuation(client_call_details, request)
+
+    class MyUnaryStreamInterceptor(grpc.aio.UnaryStreamClientInterceptor):
+      async def intercept_unary_stream(
+        self,
+        continuation: typing.Callable[
+          [grpc.aio.ClientCallDetails, MyRequestT],
+          typing.Awaitable[grpc.aio.UnaryStreamCall[MyRequestT, MyResponseT]],
+        ],
+        client_call_details: grpc.aio.ClientCallDetails,
+        request: MyRequestT,
+      ) -> typing.Union[
+        typing.AsyncIterator[MyResponseT],
+        grpc.aio.UnaryStreamCall[MyRequestT, MyResponseT],
+      ]:
+        return await continuation(client_call_details, request)
+
+    class MyStreamUnaryInterceptor(grpc.aio.StreamUnaryClientInterceptor):
+      async def intercept_stream_unary(
+        self,
+        continuation: typing.Callable[
+          [grpc.aio.ClientCallDetails, typing.Union[typing.AsyncIterable[MyRequestT], typing.Iterable[MyRequestT]]],
+          typing.Awaitable[grpc.aio.StreamUnaryCall[MyRequestT, MyResponseT]],
+        ],
+        client_call_details: grpc.aio.ClientCallDetails,
+        request_iterator: typing.Union[typing.AsyncIterable[MyRequestT], typing.Iterable[MyRequestT]],
+      ) -> typing.Union[
+        MyResponseT,
+        grpc.aio.StreamUnaryCall[MyRequestT, MyResponseT],
+      ]:
+        return await continuation(client_call_details, request_iterator)
+
+    class MyStreamStreamInterceptor(grpc.aio.StreamStreamClientInterceptor):
+      async def intercept_stream_stream(
+        self,
+        continuation: typing.Callable[
+          [grpc.aio.ClientCallDetails, typing.Union[typing.AsyncIterable[MyRequestT], typing.Iterable[MyRequestT]]],
+          typing.Awaitable[grpc.aio.StreamStreamCall[MyRequestT, MyResponseT]],
+        ],
+        client_call_details: grpc.aio.ClientCallDetails,
+        request_iterator: typing.Union[typing.AsyncIterable[MyRequestT], typing.Iterable[MyRequestT]],
+      ) -> typing.Union[
+        typing.AsyncIterator[MyResponseT],
+        grpc.aio.StreamStreamCall[MyRequestT, MyResponseT],
+      ]:
+        return await continuation(client_call_details, request_iterator)
+
+    client_interceptors = [
+      MyUnaryUnaryInterceptor(),
+      MyUnaryStreamInterceptor(),
+      MyStreamUnaryInterceptor(),
+      MyStreamStreamInterceptor(),
+    ]
     grpc.aio.insecure_channel("target", interceptors=client_interceptors)
 
-    server_interceptors = [typing.cast(grpc.aio.ServerInterceptor, "interceptor")]
+- case: aio_server_interceptors
+  main: |
+    import typing
+    import grpc
+    import grpc.aio
+
+    MyRequestT = typing.TypeVar("MyRequestT")
+    MyResponseT = typing.TypeVar("MyResponseT")
+
+    class MyServerInterceptor(grpc.aio.ServerInterceptor):
+      async def intercept_service(
+        self,
+        continuation: typing.Callable[
+          [grpc.HandlerCallDetails],
+          typing.Awaitable[grpc.RpcMethodHandler[MyRequestT, MyResponseT]],
+        ],
+        handler_call_details: grpc.HandlerCallDetails,
+      ) -> grpc.RpcMethodHandler[MyRequestT, MyResponseT]:
+        return await continuation(handler_call_details)
+
+    server_interceptors = [
+      MyServerInterceptor(),
+    ]
     grpc.aio.server(interceptors=server_interceptors)
 
 - case: service_rpc_handler_inheritance
@@ -225,7 +316,7 @@
   main: |
     import typing
     import grpc
-    
+
     class NoopInterceptor(grpc.ServerInterceptor):
         def intercept_service(
             self,


### PR DESCRIPTION
## Description of change

Fix the generic-ness of the non-aio and aio ClientInterceptors: previously an interceptor was generic over (TRequest, TResponse) meaning that an instantiated interceptor can only handle one particular RPC. This is clearly wrong, as an interceptor (which is attached to the channel) should be able to handle all RPCs. This means that an interceptor must be generic-less and the intercept methods should be generic over all (TRequest, TResponse) instead.

See the new test cases for an example of how interceptors are meant to work.

A few other fixes and tweaks too:
* Properly type serializers/deserializers with a new generic `_Serializer[_T]` and `_Deserializer[_T]`: these are just functions to/from `bytes`, confirmed by reading the Cython code.
* Fix the continuation type on the non-aio client streaming interceptors. The continuation describes the "underlying handler" and so should be passed the original request iterator, not just a single request item.
* Add a new `_Iterable[_T]` in the aio stubs as the union of `AsyncIterable[_T]` and `Iterable[_T]`, since aio client streaming methods can accept either async or non-async iterators. Note that server streaming methods always give an async iterator.
* Correct a few missing generic types here and there.

## Minimum Reproducible Example

See the added test cases.

## Checklist:

- [x] I have verified my MRE is sufficient to demonstrate the issue and solution by attempting to execute it myself
  - [ ] **OR** I believe my contribution is minor enough that a typing test is sufficient.
- [x] I have added tests to `typesafety/test_grpc.yml` for all APIs added or changed by this PR
- [x] I have removed any code generation notices from anything seeded using `mypy-protobuf`.
